### PR TITLE
Update JS socket IO to 3.1.3

### DIFF
--- a/templates/overlay/1080p.html
+++ b/templates/overlay/1080p.html
@@ -172,7 +172,7 @@ function mode_to_results(){
 
 </body>
 
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/socket.io/1.3.6/socket.io.min.js"></script>
+<script type="text/javascript" src="https://cdn.socket.io/3.1.3/socket.io.min.js"></script>
 <script type="text/javascript" charset="utf-8">
     var s = {}
 

--- a/templates/overlay/1080p_states.html
+++ b/templates/overlay/1080p_states.html
@@ -170,7 +170,7 @@ function mode_to_results(){
 
 </body>
 
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/socket.io/1.3.6/socket.io.min.js"></script>
+<script type="text/javascript" src="https://cdn.socket.io/3.1.3/socket.io.min.js"></script>
 <script type="text/javascript" charset="utf-8">
     var s = {}
 


### PR DESCRIPTION
update JS socket IO to a version that is compatible with current Engine.IO and Socket.IO. Version 1.3.6 does not work with Engine.io 4.X